### PR TITLE
Added codecov connection

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -53,3 +53,8 @@ jobs:
         working-directory: ./gradesa
         run: |
           npm run test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+    patch:
+      default:
+        target: 0%
+        threshold: 100%


### PR DESCRIPTION
I can't see the configuration in Codecov yet ([https://app.codecov.io/gh/OHTU-German-learning-website](https://app.codecov.io/gh/OHTU-German-learning-website)) but I'm wondering could it be because this is not merged with the master branch. 